### PR TITLE
feat(stax-orchestrator): dont use docker to build the app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ prepare-lambda-layer-dir: clean ## Build lambda layer with shared dependencies
 	pip install -r requirements.txt -t lambda_layer
 	cp -R src/* lambda_layer
 
-build-app: prepare-lambda-layer-dir ## Use docker and sam to build the app locally
-	sam build --use-container
+build-app: prepare-lambda-layer-dir ## Use sam to build the app locally
+	sam build
 
 run-create-workload-lambda-locally: ## Invoke CreateWorkloadLambda running in a docker container locally
 	sam local invoke CreateWorkloadLambda -e events/create_workload_innovation.json

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ You can find more information and examples about filtering Lambda function logs 
         "aws_region": "ap-southeast-2",
         "operation": "deploy",
         "catalogue_id": "b3437e3b-55e3-4060-9dec-042f18dcf789",
-        "catalogue_version_id": "545dca4",
+        "catalogue_version_id": "69e4a16c-7c7c-48cf-bb8d-312c43fc0563",
         "workload_name": "orchestrator-stax-demo-vpc",
         "workload_parameters": {
             "Param1": "Value1"
@@ -135,7 +135,7 @@ You can find more information and examples about filtering Lambda function logs 
     {
         "operation": "update",
         "workload_id": "b3437e3b-55e3-4060-9dec-042f18dcf789",
-        "catalogue_version_id": "545dca4"
+        "catalogue_version_id": "69e4a16c-7c7c-48cf-bb8d-312c43fc0563"
     }
     ```
     * workload_id - The ID of the workload to update


### PR DESCRIPTION
Using docker to build the application takes a lot of time and is unsuitable for the CI/CD process. Remove the use of docker to build the application.