### PR TITLE
feat(stax-orchestrator): Cloudwatch dashboard for Stax Orchestrator.

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -244,10 +244,10 @@ Resources:
             Action:
               - ssm:GetParameter
             Resource:
-            # yamllint disable rule:line-length
+              # yamllint disable rule:line-length
               - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/orchestrator/stax/access/key
               - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/orchestrator/stax/access/key/secret
-            # yamllint enable rule:line-length
+              # yamllint enable rule:line-length
 
   StaxOrchestratorSfnPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -264,9 +264,9 @@ Resources:
               - events:PutRule
               - events:DescribeRule
             Resource:
-            # yamllint disable rule:line-length
+              # yamllint disable rule:line-length
               - !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule
-            # yamllint enable rule:line-length
+              # yamllint enable rule:line-length
           - Effect: Allow
             Action:
               - xray:PutTraceSegments
@@ -311,6 +311,7 @@ Resources:
     Type: AWS::CloudWatch::Dashboard
     Properties:
       DashboardName: StaxOrchestrator
+      # yamllint disable rule:line-length
       DashboardBody: !Sub |
             {
               "widgets": [
@@ -446,6 +447,7 @@ Resources:
                 }
               ]
             }
+      # yamllint disable rule:line-length
 
 Outputs:
   WorkloadArn:


### PR DESCRIPTION
Deployed in Innovation to test, looks like,
<img width="2042" alt="Screen Shot 2022-08-08 at 9 21 03 am" src="https://user-images.githubusercontent.com/42393225/183315079-668f555e-c003-4899-bb26-2eb4a5db4cb4.png">
