### PR TITLE
ci(PullRequestWorkflows): correct event to base changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-form.yml
+++ b/.github/ISSUE_TEMPLATE/bug-form.yml
@@ -39,7 +39,7 @@ body:
     attributes:
       label: Relevant log output
       description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
-      render: shell
+      render: Shell
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/workflows/cfn-lint.yml
+++ b/.github/workflows/cfn-lint.yml
@@ -2,7 +2,7 @@
 name: Lint CloudFormation Templates
 
 on: 
-  pull_request_target:
+  pull_request:
 
 
 jobs:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -5,7 +5,7 @@
 # Source repository: https://github.com/actions/dependency-review-action
 # Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
 name: 'Dependency Review'
-on: [pull_request_target]
+on: [pull_request]
 
 permissions:
   contents: read

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,7 +1,7 @@
 ---
 name: Python Lint
 on: 
-  pull_request_target:
+  pull_request:
 
 jobs:
   lint-python:

--- a/.github/workflows/state-lint.yml
+++ b/.github/workflows/state-lint.yml
@@ -2,8 +2,7 @@
 name: AWS States Lint
 
 on: 
-  fork:
-  pull_request_target:
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -1,7 +1,7 @@
 ---
 name: Yaml Lint
 on: 
-  pull_request_target:
+  pull_request:
 
 jobs:
   lint-yaml:


### PR DESCRIPTION
### Correction on where to base the context when running actions

### Contribution Type

- [ ] Issue (Feature)
- [x] Issue (Bug Fix)
- [ ] Security Update

### Design Decisions

`pull_request_target` runs the workflow while based on the base branch - for unit testing, this doesn't test the code that the user plans to merge - rather the code that is already in the `main` branch.

Using `pull_request` event will correctly run the unit tests against what the user is submitting in the pull_request.

### Testing

N/A
